### PR TITLE
Update: improve python test env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 
 language: python
 python:
-  - "2.7"
   - "3.6"
+  - "3.7"
 
 sudo: required
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{27,36}-ansible{26,27,28}
+envlist = py{36,37}-ansible{26,27,28}
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
 - drop 2.7 (it's old and deprecated)
 - run on 3.6 and 3.7 (which we actually use)