### PR TITLE
Fix: make sure the docker-cli version is the same as dockerd

### DIFF
--- a/tasks/setup-docker-engine.yml
+++ b/tasks/setup-docker-engine.yml
@@ -24,6 +24,12 @@
     name: "{{ docker_package_name }}{{ _docker_package_version | default('') }}"
     state: "{{ docker_package_state }}"
 
+- name: Explicitly install/Update Docker CLI too, on RedHat distros
+  when: ansible_os_family == 'RedHat'
+  package:
+    name: "{{ docker_package_name }}-cli{{ _docker_package_version | default('') }}"
+    state: "{{ docker_package_state }}"
+
 - name: Make sure the Docker daemon configuration directory exists
   file:
     path: /etc/docker


### PR DESCRIPTION
Otherwise, it seems to keep the old docker-cli, and only update the docker engine.